### PR TITLE
Add Blocks For 2D Gravity

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -125,7 +125,104 @@ namespace Math {
 
 namespace sprites {
 
- 
+    //% block="applyInstant2DGravityVelocity $sprite=variables_get(mySprite) Sprite Mass $massSprite Object Mass $massObject xOffset $xOffset yOffset $yOffset"
+    //% group="Gravity"
+    //% weight=98
+    /**
+     * Applies instantenous velocity due to gravity to a sprite.
+     * Does not return
+     * @param sprite - the sprite that will be acted upon
+     * @param massSprite - the mass in kg that the sprite has
+     * @param massObject - the mass of the object that the sprite is being pulled to
+     * @param xOffset - the horizontal distance between the object and the sprite, should be positive if to the right, negative if to the left
+     * @param yOffset - the vertical distance between the object and the sprite, should be positive if above, negative if below
+     */
+    export function applyInstant2DGravityVelocity(sprite: Sprite, 
+      massSprite: number, 
+      massObject: number, 
+      xOffset: number,
+      yOffset: number) {
+
+        xOffset = -xOffset;
+
+        const gravitationalAcceleration = computeGravitationalEffect(massSprite,
+            massObject,
+            xOffset,
+            yOffset);
+
+        const newVelocity = {
+            ax: gravitationalAcceleration.ax + sprite.vx,
+            ay: gravitationalAcceleration.ay + sprite.vy
+        }
+
+        sprite.setVelocity(newVelocity.ax, newVelocity.ay)
+    }
+
+    //% block="applyInstant2DGravityAcceleration $sprite=variables_get(mySprite) Sprite Mass $massSprite Object Mass $massObject xOffset $xOffset yOffset $yOffset"
+    //% group="Gravity"
+    //% weight=98
+    /**
+     * Applies instantaneous acceleration due to gravity on a sprite.
+     * Does not return
+     * @param sprite - the sprite that will be acted upon
+     * @param massSprite - the mass in kg that the sprite has
+     * @param massObject - the mass of the object that the sprite is being pulled to
+     * @param xOffset - the horizontal distance between the object and the sprite, should be positive if to the right, negative if to the left
+     * @param yOffset - the vertical distance between the object and the sprite, should be positive if above, negative if below
+     */
+    export function applyInstant2DGravityAcceleration (sprite: Sprite, 
+      massSprite: number, 
+      massObject: number, 
+      xOffset: number,
+      yOffset: number) {
+
+        xOffset = -xOffset;
+
+        const gravitationalAcceleration = computeGravitationalEffect(massSprite,
+            massObject,
+            xOffset,
+            yOffset);
+
+        const newAcceleration = {
+            ax: gravitationalAcceleration.ax + sprite.ax,
+            ay: gravitationalAcceleration.ay + sprite.ay
+        }
+
+        sprite.ax = newAcceleration.ax
+        sprite.ay = newAcceleration.ay
+
+    }
+
+    /**
+     * computes gravity's effect on an object
+     */
+    const computeGravitationalEffect = (massSprite: number, 
+      massObject: number, 
+      xOffset: number, 
+      yOffset: number) => {
+
+        const spriteDistance = distance(yOffset, xOffset);
+        const forceOfGravity = gravitationalForce(massSprite, massObject, spriteDistance);
+
+        // first, find the gravitational acceleration that we should have
+        const gravitationalAcceleration = {
+            ax: forceOfGravity * (xOffset / spriteDistance),
+            ay: forceOfGravity * (yOffset / spriteDistance)
+        }
+
+        return gravitationalAcceleration;        
+      }
+
+    const distance = (yOffset: number, xOffset: number) => {
+        const squaredDistance = xOffset * xOffset + yOffset * yOffset;
+        return Math.sqrt(squaredDistance);
+    }
+
+    const gravitationalForce = (massOne: number, massTwo: number, radius: number) => {
+        const gravitationalConstant = 0.00000000006673
+
+        return gravitationalConstant * ((massOne * massTwo) / Math.pow(radius, 2))
+    }
 
     //% block="record $sprite=variables_get(mySprite) heading"
     //% group="Heading"

--- a/main.ts
+++ b/main.ts
@@ -130,7 +130,6 @@ namespace sprites {
     //% weight=98
     /**
      * Applies instantenous velocity due to gravity to a sprite.
-     * Does not return
      * @param sprite - the sprite that will be acted upon
      * @param massSprite - the mass in kg that the sprite has
      * @param massObject - the mass of the object that the sprite is being pulled to
@@ -163,7 +162,6 @@ namespace sprites {
     //% weight=98
     /**
      * Applies instantaneous acceleration due to gravity on a sprite.
-     * Does not return
      * @param sprite - the sprite that will be acted upon
      * @param massSprite - the mass in kg that the sprite has
      * @param massObject - the mass of the object that the sprite is being pulled to

--- a/main.ts
+++ b/main.ts
@@ -125,37 +125,6 @@ namespace Math {
 
 namespace sprites {
 
-    //% block="applyInstant2DGravityVelocity $sprite=variables_get(mySprite) Sprite Mass $massSprite Object Mass $massObject xOffset $xOffset yOffset $yOffset"
-    //% group="Gravity"
-    //% weight=98
-    /**
-     * Applies instantenous velocity due to gravity to a sprite.
-     * @param sprite - the sprite that will be acted upon
-     * @param massSprite - the mass in kg that the sprite has
-     * @param massObject - the mass of the object that the sprite is being pulled to
-     * @param xOffset - the horizontal distance between the object and the sprite, should be positive if to the right, negative if to the left
-     * @param yOffset - the vertical distance between the object and the sprite, should be positive if above, negative if below
-     */
-    export function applyInstant2DGravityVelocity(sprite: Sprite, 
-      massSprite: number, 
-      massObject: number, 
-      xOffset: number,
-      yOffset: number) {
-
-        xOffset = -xOffset;
-
-        const gravitationalAcceleration = computeGravitationalEffect(massSprite,
-            massObject,
-            xOffset,
-            yOffset);
-
-        const newVelocity = {
-            ax: gravitationalAcceleration.ax + sprite.vx,
-            ay: gravitationalAcceleration.ay + sprite.vy
-        }
-
-        sprite.setVelocity(newVelocity.ax, newVelocity.ay)
-    }
 
     //% block="applyInstant2DGravityAcceleration $sprite=variables_get(mySprite) Sprite Mass $massSprite Object Mass $massObject xOffset $xOffset yOffset $yOffset"
     //% group="Gravity"
@@ -217,7 +186,7 @@ namespace sprites {
     }
 
     const gravitationalForce = (massOne: number, massTwo: number, radius: number) => {
-        const gravitationalConstant = 0.00000000006673
+        const gravitationalConstant = 6673
 
         return gravitationalConstant * ((massOne * massTwo) / Math.pow(radius, 2))
     }

--- a/pxt.json
+++ b/pxt.json
@@ -14,7 +14,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "1.0.14",
+        "target": "1.0.15",
         "targetId": "arcade"
     },
     "supportedTargets": [


### PR DESCRIPTION
Add the `applyInstant2DGravityVelocity` and `applyInstant2DGravityAcceleration` blocks to pxt-turtlelogo.

Also, it wouldn't let me revert the change to pxt.json, idk why that happened.

### Possible Bug

There may be a possible bug here, I tried to diagnose but I can't seem to find a cause except to think that there might be an issue with Makecode, but I'm not sure. This is hard to explain, so hopefully I can enumerate it well enough to be understood. (also, just realized I accidentally swapped the mass of the sprite and object, behavior should be the same still)

When the acceleration of the X & Y components is less than 1, it seems that the sprite takes a path that is flatter than what it should. For instance, given [these parameters](#Ends-Above-Bottom-Left-Corner) the sprite will end up going off-screen above the bottom left corner. When you up the [gravity on the object by 1000](#ends-to-the-left-of-bottom-left-corner), it will end up going off-screen to the _left_ of the bottom left center. Assuming the box that we are viewing is a square (which I think it is) it should be ending up in the bottom left corner exactly every time. Even if it it is a rectangle instead of a square, I don't imagine that changing the magnitude of velocity should change the path the object takes.

The use case for these blocks was to drag something towards the center, if the objects are going off of their expected course they may miss their target and fly off-screen instead, possibly breaking the game. 

Maybe this is just an edge case issue that won't be able to be replicated, just thought I'd give a heads up about it.


###### Ends Above Bottom Left Corner
```js
{
  "massSprite": 100000000000000,
  "massObject": 1,
  "xOffset": 100
  "yOffset": 100
}
```

###### Ends to the Left of Bottom Left Corner
```js
{
  "massSprite": 100000000000000000,
  "massObject": 1,
  "xOffset": 100
  "yOffset": 100
}
```